### PR TITLE
Remove subexes - More fixes for Nim 1.0+

### DIFF
--- a/httpauth.nim
+++ b/httpauth.nim
@@ -24,8 +24,7 @@ import libsodium/sodium_sizes
 import httpauthpkg/[base,
   mailer,
   json_backend,
-  sql_backend,
-  format_templates]
+  sql_backend]
 
 export newJsonBackend,
   newSQLBackend,
@@ -392,13 +391,15 @@ proc send_password_reset_email*(self: HTTPAuth, username="", email_addr="",
   # generate a reset_code token
   let reset_code = self.generate_reset_code(user.username, user.email_addr)
 
+  const reset_time_format = "YYYY-MM-dd hh:mm:ss"
+
   # send reset email
   let registration_email_fn = "password_reset_email.tpl"
   let registration_email_tpl = registration_email_fn.readFile()
   let email_text = registration_email_tpl.format(
     "username", username,
     "reset_code", reset_code,
-    "reset_time", getTime().getGMTime()
+    "reset_time", getTime().getGMTime().format(reset_time_format)
   )
 
   assert self.mailer.sender_email_addr != ""

--- a/httpauthpkg/cookiejar.nim
+++ b/httpauthpkg/cookiejar.nim
@@ -74,10 +74,11 @@ proc parseSetCookie*(header: string): Cookie =
       if not (val.endswith(" GMT") or val.endswith(" UTC")):
         continue
       result.session = false
-      var exp = parse(val, "ddd, dd MMM yyyy HH:mm:ss")
+      let zone = utc()
+      var exp = parse(val, "ddd, dd MMM yyyy HH:mm:ss", zone)
       #         parse(v, "ddd, dd MMM yy HH:mm:SS")
       exp.isDST = false
-      exp.timezone = 0
+      exp.timezone = zone
       result.expires = toTime exp
     of "secure":
       result.secure = true
@@ -102,11 +103,11 @@ proc add_cookies*(jar: var CookieJar, raw_cookies: seq[string], domain, path: st
   for rc in raw_cookies:
     var cookie = parseSetCookie(rc)
 
-    if cookie.domain == nil:
+    if cookie.domain.len == 0:
       cookie.domain = domain
       cookie.host_only = true
 
-    if cookie.path == nil:
+    if cookie.path.len == 0:
       cookie.path = path
 
     if cookie.session or (cookie.expires > getTime()):

--- a/password_reset_email.tpl
+++ b/password_reset_email.tpl
@@ -1,5 +1,5 @@
 Hello $username,<br/>
-You are receiving this email because you requested a password reset on HTTPAuth Demo Webapp on $reset_time.<br/>
+You are receiving this email because you requested a password reset on HTTPAuth Demo Webapp on $reset_time GMT.<br/>
 <br/>
 If you wish to complete the password reset please click on:<br/>
 <a href="http://localhost:8080/reset_password/$reset_code">Confirm</a>

--- a/password_reset_email.tpl
+++ b/password_reset_email.tpl
@@ -1,6 +1,6 @@
-Hello ${1},<br/>
-You are receiving this email because you requested a password reset on HTTPAuth Demo Webapp on ${4}.<br/>
+Hello $username,<br/>
+You are receiving this email because you requested a password reset on HTTPAuth Demo Webapp on $reset_time.<br/>
 <br/>
 If you wish to complete the password reset please click on:<br/>
-<a href="http://localhost:8080/reset_password/${3}">Confirm</a>
+<a href="http://localhost:8080/reset_password/$reset_code">Confirm</a>
 <br/><br/>

--- a/registration_email.tpl
+++ b/registration_email.tpl
@@ -1,8 +1,8 @@
-Hello ${1},<br/>
-You are receiving this email because you registered on the HTTPAuth Demo Webapp on ${2}.<br/>
+Hello $username,<br/>
+You are receiving this email because you registered on the HTTPAuth Demo Webapp on $url.<br/>
 <br/>
 If you wish to complete the registration please click on:<br/>
-<a href="http://localhost:8080/validate_registration/${3}">Confirm</a>
+<a href="http://localhost:8080/validate_registration/$registration_code">Confirm</a>
 <br/><br/>
-Your email address is: ${4}<br/>
-Your role will be: ${5}.<br/>
+Your email address is: $email_addr<br/>
+Your role will be: $role.<br/>


### PR DESCRIPTION
I revised the password reset and registration email templates - these used the subexes package, which was removed in Nim 1.0+, so I updated them and the formatting code to used the new strutils templates.

(This is on top of my earlier changes, but I can rebase / make those separate if needed).